### PR TITLE
Update to trash v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Update trash to v3.
+
 # 1.0.0 - 2015-10-04
 
 ✨ Initial release

--- a/npmpublish.sh
+++ b/npmpublish.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
-./node_modules/.bin/trash node_modules &>/dev/null;
+trashCli=$(node -e "var path = require('path');console.log(path.join(path.dirname(require('fs').realpathSync('$0')), 'node_modules/.bin/trash'))");
+node "$trashCli" node_modules &&
 git pull --rebase &&
 npm install &&
 npm test &&

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "npmpublish": "npmpublish.sh"
   },
   "dependencies": {
-    "trash": "^2.0.0"
+    "trash": "^3.4.1"
   },
   "devDependencies": {
     "github-release-from-changelog": "^1.0.0"


### PR DESCRIPTION
In prep for https://github.com/stylelint/stylelint/issues/401, trash v2 now throws deprecated warnings.

Trash cli change is from https://github.com/sindresorhus/np/commit/1c3477087eddb2cf7667777df133f51ec6d21afb
