### PR TITLE
Fixed: tags are now annotated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# 3.1.1 - 2016-12-16
+
+- Fixed: tags are now annotated tags.
+
 # 3.1.0 - 2016-03-12
 
 - Added: ``--skip-test``, because you might need it for shitty test runner
-  (eg: ``testling`` don't like to be ran from another location).  
+  (eg: ``testling`` don't like to be ran from another location).
   **That's a pretty stupid option, I agree.**
 
   _Recommended Usage: ``npm test && npmpub --skip-test``._

--- a/npmpub.js
+++ b/npmpub.js
@@ -170,7 +170,8 @@ cleanupPromise
       }
 
       log("Tagging.")
-      const gitTag = exec("git tag " + version)
+      const gitTag = exec("git tag -m \"Release version " + version
+        + "created with npmpub\" -a " + version)
       if (gitTag.code !== 0) {
         error("Tagging failed.")
         exit(1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmpub",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "`npm publish` on steroid",
   "keywords": [
     "cli-app",


### PR DESCRIPTION
While discussing https://github.com/MoOx/npmpub/issues/14 it was discovered that the tags created by npmpub are not annotated. This PR fixes that.