### PR TITLE
Fix a bug when checking upstream using Git in a Windows environment

### DIFF
--- a/npmpub.js
+++ b/npmpub.js
@@ -27,7 +27,7 @@ const error = (msg) => print(colors.red.bold(msg))
 const cmds = {
   gitStatus: "git status --porcelain",
   gitFetch: "git fetch --quiet",
-  gitCheckRemote: "git rev-list --count --left-only @'{u}'...HEAD",
+  gitCheckRemote: "git rev-list --count --left-only @{u}...HEAD",
 }
 
 if (argv["help"]) {


### PR DESCRIPTION
Git in a Windows environment doesn't recognize the single quotes in `@'{u}'`.

Fixes #19.