### PR TITLE
Add a --skip-tag command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ npmpub [options]
 --skip-fetch    Skip git fetch to compare remote (⚠︎ you might not be able to push).
 --skip-compare  Skip git comparison with origin (⚠︎ you might not be able to push).
 --skip-cleanup  Skip node_modules cleanup (⚠︎ you might miss some dependencies changes).
+--skip-tag      Skip checking for, adding, and pushing a tag with the new version number.
 --skip-test     Skip test (⚠︎ USE THIS VERY CAREFULLY).
 --dry           No publish, just check that tests are ok.
 --no-release    No GitHub release from changelog.


### PR DESCRIPTION
This option skips checking for, adding, and pushing a tag with the new version number.