### PR TITLE
Use `npm install` if no lock files found

### DIFF
--- a/npmpub.js
+++ b/npmpub.js
@@ -23,6 +23,7 @@ const error = msg => print(colors.red.bold(msg));
 
 const cmds = {
   isYarn: "ls yarn.lock",
+  isPackageLockPresent: "ls package-lock.json",
   install: undefined, // defined after isYarn test
   gitStatus: "git status --porcelain",
   gitFetch: "git fetch --quiet",
@@ -56,7 +57,22 @@ const isYarn = exec(cmds.isYarn, execOpts).code === 0;
 if (isYarn) {
   log("Yarn detected.");
 }
-cmds.install = isYarn ? "yarn --frozen-lockfile" : "npm ci";
+
+// check if package-lock is used
+debug(cmds.isPackageLockPresent);
+const isPackageLockPresent =
+  exec(cmds.isPackageLockPresent, execOpts).code === 0;
+if (isPackageLockPresent) {
+  log("package-lock.json detected.");
+}
+
+if (isYarn) {
+  cmds.install = "yarn --frozen-lockfile";
+} else if (isPackageLockPresent) {
+  cmds.install = "npm ci";
+} else {
+  cmds.install = "npm install";
+}
 
 // check clean status
 if (argv["skip-status"]) {


### PR DESCRIPTION
We at stylelint faced [a problem](https://github.com/stylelint/stylelint/issues/3456#issuecomment-407567950): we couldn't release with new npmpub 4, because we don't use `package-lock.json`. We don't use it, because we need to be sure, that users, who rely on SemVer, won't get breaking stylelint. ([related discussion](https://github.com/stylelint/stylelint/pull/3377#issuecomment-395584732)).

This PR allow npmpub to use `npm install` if no lockfiles are found. It removes breaking change from v4, while not break anything else.