### PR TITLE
Add support for `otp` and `access=public` `npm publish` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ npmpub [options]
 --skip-compare  Skip git comparison with origin (⚠︎ you might not be able to push).
 --skip-cleanup  Skip node_modules cleanup (⚠︎ you might miss some dependencies changes).
 --skip-test     Skip test (⚠︎ USE THIS VERY CAREFULLY).
+--otp           Prompt for npm's 2FA one-time-password before publishing
+--public        Set access to public when publishing @scoped/package
 --dry           No publish, just check that tests are ok.
 --no-release    No GitHub release from changelog.
 ```

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "eslintConfig": {
     "parserOptions": {
-      "ecmaVersion": 6
+      "ecmaVersion": 2017
     },
     "env": {
       "node": true,


### PR DESCRIPTION
- Add support for otp flag for npm publish (fixes #27)
- Add support for access=public flag for npm publish 
_this is needed e.g. when a scoped package (@foo/my-package) is released. I think the public option could even be used always or as default because npmpub will be used in open source repos. but I added it as an opt-in flag_
- Update eslint ES parse version to support async/await syntax
_updated to ES2017. Package.json says node v8 and higher is supported. v8 has all the es2017 stuff except shared array buffers and Atomics._